### PR TITLE
mobile padding 16px, made mobile screens full, large screens centered

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -101,8 +101,8 @@ export default function CustomLayout({
       <Content
         style={{
           paddingTop: "24px",
-          paddingRight: screens.sm ? 48 : 8,
-          paddingLeft: screens.sm ? 48 : 8,
+          paddingRight: screens.sm ? 48 : 16,
+          paddingLeft: screens.sm ? 48 : 16,
           height: `calc(100% - ${headerHeight}px)`,
           overflow: "auto",
           display: "flex",

--- a/components/calculator/Calculator.tsx
+++ b/components/calculator/Calculator.tsx
@@ -203,7 +203,9 @@ export function Calculator({ stakers, currentGgpPriceInAvax, avaxPriceInUsd }: P
     <>
       <Space direction="vertical">
         <Row>
-          <Col xxl={6} lg={8} xs={16}>
+          <Col xxl={4} lg={2}>
+          </Col>
+          <Col xxl={6} lg={8} sm={20} xs={24}>
             <Title>Minipool Rewards Calculator</Title>
             <Typography>
               <Paragraph style={{ fontSize: 18 }}>
@@ -212,9 +214,9 @@ export function Calculator({ stakers, currentGgpPriceInAvax, avaxPriceInUsd }: P
               </Paragraph>
             </Typography>
           </Col>
-          <Col lg={2} sm={0} xs={0}>
+          <Col lg={2} xs={0}>
           </Col>
-          <Col xxl={6} lg={8} xs={14}>
+          <Col xxl={6} lg={8} sm={16} xs={24}>
             <ProtocolSettings
               ggpPriceInAvax={ggpPriceInAvax}
               setGgpPriceInAvax={setGgpPriceInAvax}
@@ -226,7 +228,9 @@ export function Calculator({ stakers, currentGgpPriceInAvax, avaxPriceInUsd }: P
           </Col>
         </Row>
         <Row>
-          <Col xxl={6} lg={8} xs={16}>
+          <Col xxl={4} lg={2}>
+          </Col>
+          <Col xxl={6} lg={8} sm={16} xs={24}>
             <YourMinipool
               numMinipools={numMinipools}
               avaxAmount={avaxAmount}
@@ -239,7 +243,7 @@ export function Calculator({ stakers, currentGgpPriceInAvax, avaxPriceInUsd }: P
           </Col>
           <Col lg={2} xs={0}>
           </Col>
-          <Col xxl={8} lg={10} xs={20}>
+          <Col xxl={8} lg={10} sm={20} xs={24}>
             <YourMinipoolResults
               ggpCollatPercent={ggpCollatPercent}
               realGgpAmount={realGgpAmount}

--- a/components/calculator/YourMinipool.tsx
+++ b/components/calculator/YourMinipool.tsx
@@ -78,7 +78,9 @@ export function YourMinipool({
             onChange={handlePercentChange}
           />
         </Col>
-        <Col span={24}>
+        <Col span={1}>
+        </Col>
+        <Col span={21}>
           <Slider
             style={{ width: "100%" }}
             min={10}


### PR DESCRIPTION
### Calculator styling changes
- large screens centered to have less empty space on the right side.  
- XS screens (< 576px) now have full width inputs and copy. 
- Changed layout so small screen padding is 16px instead of 8px (across the app). 